### PR TITLE
libstdc++: disable embedded tzdata for esp toolchain

### DIFF
--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -5681,6 +5681,14 @@ AC_DEFUN([GLIBCXX_ZONEINFO_DIR], [
 		   [the location to use for tzdata]),
     [],[with_libstdcxx_zoneinfo=yes])
 
+  case ${host} in
+    *-esp*)
+      if test "x${with_libstdcxx_zoneinfo}" = xyes; then
+	with_libstdcxx_zoneinfo=no
+      fi
+      ;;
+  esac
+
   if test "x${with_libstdcxx_zoneinfo}" = xyes; then
     # Pick a default when no specific path is set.
     case "$target_os" in

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -54350,6 +54350,14 @@ else
 fi
 
 
+  case ${host} in
+    *-esp*)
+      if test "x${with_libstdcxx_zoneinfo}" = xyes; then
+	with_libstdcxx_zoneinfo=no
+      fi
+      ;;
+  esac
+
   if test "x${with_libstdcxx_zoneinfo}" = xyes; then
     # Pick a default when no specific path is set.
     case "$target_os" in


### PR DESCRIPTION
Fixes espressif/esp-idf#18522.

The static `tzdata.zi` file embedded by libstdc++ for `std::chrono::tzdb` adds ~105KB to the library and ends up in final binaries whenever third-party code touches the relevant chrono APIs, even though it is rarely used in an embedded context. Disable it by default for `*-esp*` hosts.